### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": "^7.1",
+        "php": "~7.1",
         "doctrine/persistence": "^1.0"
     }
 }


### PR DESCRIPTION
Change required php version to ~7.1 to allow usage of php version 7.1.24.

At the moment the installation fails on php version 7.1.24 because of this problem:

``` 
Problem 1
    - bolt/package-wrapper v4.0.0 requires php <7.1 -> your PHP version (7.1.24) does not satisfy that requirement.
    - bolt/package-wrapper v4.0.0 requires php <7.1 -> your PHP version (7.1.24) does not satisfy that requirement.
    - Installation request for bolt/package-wrapper v4.0.0 -> satisfiable by bolt/package-wrapper[v4.0.0].
```